### PR TITLE
Save user_id upon login and signup

### DIFF
--- a/src/api-client/ApiClient.js
+++ b/src/api-client/ApiClient.js
@@ -20,7 +20,7 @@ export async function createUser(createUserRequest) {
 	if (result.error) {
 		return { error: result.error };
 	}
-	return { logic_token: result.logic_token, db_token: result.db_token };
+	return { logic_token: result.logic_token, db_token: result.db_token, user_id: result.user_id };
 }
 
 export async function login(loginRequest) {
@@ -35,17 +35,19 @@ export async function login(loginRequest) {
 	if (result.error) {
 		return { error: result.error };
 	}
-	return { logic_token: result.logic_token, db_token: result.db_token };
+	return { logic_token: result.logic_token, db_token: result.db_token, user_id: result.user_id };
 }
 
 export async function makeAuthenticatedRequest(endpoint, options = {}) {
 	const logicToken = localStorage.getItem('logic_token');
 	const dbToken = localStorage.getItem('db_token');
+	const userId = localStorage.getItem('user_id');
 
 	const headers = {
 		...options.headers,
 		Authorization: `Bearer ${logicToken}`,
 		'X-Db-Token': dbToken,
+		'X-User-ID': userId,
 	};
 
 	const response = await fetch(`${API_BASE_URL}${endpoint}`, {

--- a/src/api-client/ApiClient.test.js
+++ b/src/api-client/ApiClient.test.js
@@ -12,6 +12,7 @@ describe('ApiClient', () => {
 			const mockResponse = {
 				logic_token: 'logicToken123',
 				db_token: 'dbToken456',
+				user_id: 'user1'
 			};
 
 			// Mocking the fetch API response
@@ -28,7 +29,6 @@ describe('ApiClient', () => {
 				password: 'hashedPassword123',
 				bio: 'test bio',
 				phone: '1234567890',
-				preferences: ['preference1', 'preference2'],
 			};
 
 			const result = await createUser(createUserRequest);
@@ -43,6 +43,7 @@ describe('ApiClient', () => {
 			expect(result).toEqual({
 				logic_token: 'logicToken123',
 				db_token: 'dbToken456',
+				user_id: 'user1'
 			});
 		});
 
@@ -72,6 +73,7 @@ describe('ApiClient', () => {
 			const mockResponse = {
 				logic_token: 'logicToken123',
 				db_token: 'dbToken456',
+				user_id: 'user1'
 			};
 
 			global.fetch = jest.fn(() =>
@@ -101,6 +103,7 @@ describe('ApiClient', () => {
 			expect(result).toEqual({
 				logic_token: 'logicToken123',
 				db_token: 'dbToken456',
+				user_id: 'user1'
 			});
 		});
 
@@ -132,6 +135,7 @@ describe('ApiClient', () => {
 				getItem: jest.fn((key) => {
 					if (key === 'logic_token') return 'logicToken123';
 					if (key === 'db_token') return 'dbToken456';
+					if (key === 'user_id') return 'user1';
 					return null;
 				}),
 			};
@@ -157,6 +161,7 @@ describe('ApiClient', () => {
 				headers: {
 					Authorization: 'Bearer logicToken123',
 					'X-Db-Token': 'dbToken456',
+					'X-User-ID': 'user1'
 				},
 			});
 			expect(result).toEqual(mockResponse);
@@ -170,6 +175,7 @@ describe('ApiClient', () => {
 				getItem: jest.fn((key) => {
 					if (key === 'logic_token') return 'logicToken123';
 					if (key === 'db_token') return 'dbToken456';
+					if (key === 'user_id') return 'user1';
 					return null;
 				}),
 			};

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -33,6 +33,7 @@ const Login = () => {
 		} else {
 			localStorage.setItem('logic_token', result.logic_token);
 			localStorage.setItem('db_token', result.db_token);
+			localStorage.setItem('user_id', result.user_id);
 			setError('');
 			navigate('/');
 		}

--- a/src/components/Login.test.js
+++ b/src/components/Login.test.js
@@ -75,6 +75,7 @@ describe('Login Component', () => {
 		ApiClient.login.mockResolvedValueOnce({
 			logic_token: 'logicToken123',
 			db_token: 'dbToken456',
+			user_id: 'user1'
 		});
 
 		render(
@@ -102,6 +103,10 @@ describe('Login Component', () => {
 			expect(localStorage.setItem).toHaveBeenCalledWith(
 				'db_token',
 				'dbToken456'
+			);
+			expect(localStorage.setItem).toHaveBeenCalledWith(
+				'user_id',
+				'user1'
 			);
 			expect(mockNavigate).toHaveBeenCalledWith('/');
 		});

--- a/src/components/Signup.js
+++ b/src/components/Signup.js
@@ -33,26 +33,11 @@ const Signup = () => {
 	const [confirmPassword, setConfirmPassword] = useState('');
 	const [bio, setBio] = useState('');
 	const [phone, setPhone] = useState('');
-	// const [preferences, setPreferences] = useState("");
-	// const [preferencesList, setPreferencesList] = useState([]);
 	const [imageBlob, setImageBlob] = useState(null);
 	const [passwordError, setPasswordError] = useState('');
 	const [emailError, setEmailError] = useState('');
 	const [phoneError, setPhoneError] = useState('');
 	const [signupError, setSignupError] = useState('');
-
-	// const handleAddPreference = () => {
-	//   if (preferences) {
-	//     setPreferencesList([...preferencesList, preferences]);
-	//     setPreferences("");
-	//   }
-	// };
-
-	// const handleRemovePreference = (index) => {
-	//   const newList = [...preferencesList];
-	//   newList.splice(index, 1);
-	//   setPreferencesList(newList);
-	// };
 
 	const handleNameChange = (e) => setName(e.target.value);
 
@@ -117,7 +102,6 @@ const Signup = () => {
 			password: hashedPassword,
 			bio,
 			phone,
-			// preferences: preferencesList,
 		};
 
 		const result = await createUser(userRequest);
@@ -126,6 +110,7 @@ const Signup = () => {
 		} else {
 			localStorage.setItem('logic_token', result.logic_token);
 			localStorage.setItem('db_token', result.db_token);
+			localStorage.setItem('user_id', result.user_id);
 			navigate('/');
 		}
 	};

--- a/src/components/Signup.test.js
+++ b/src/components/Signup.test.js
@@ -93,6 +93,7 @@ describe('Signup Component', () => {
 		ApiClient.createUser.mockResolvedValueOnce({
 			logic_token: 'logicToken123',
 			db_token: 'dbToken456',
+			user_id: 'user1'
 		});
 
 		render(
@@ -132,6 +133,10 @@ describe('Signup Component', () => {
 			expect(localStorage.setItem).toHaveBeenCalledWith(
 				'db_token',
 				'dbToken456'
+			);
+			expect(localStorage.setItem).toHaveBeenCalledWith(
+				'user_id',
+				'user1'
 			);
 			expect(mockNavigate).toHaveBeenCalledWith('/');
 		});


### PR DESCRIPTION
## Included
- Save `user_id` in local storage when a user logs in or signs up
- Send `user_id` along any authenticated request